### PR TITLE
CHECK-134: BE: Fix registerAdminService to change user's role to Admin

### DIFF
--- a/app/Http/Controllers/RegisterAdminController.php
+++ b/app/Http/Controllers/RegisterAdminController.php
@@ -35,13 +35,16 @@ class RegisterAdminController extends Controller
       $request['logo']
     );
 
-    $user = $this->registerAdminUtility->registerAdminUser(
+    $admin = $this->registerAdminUtility->registerAdminUser(
       $name,
       $request['email'],
       $request['password'],
       $organization->id
     );
+    
+    $user = $admin[0];
+    $role = $admin[2]->name;
 
-    return compact(['organization', 'user']);
+    return compact(['organization', 'user', 'role']);
   }
 }

--- a/app/Models/UserRole.php
+++ b/app/Models/UserRole.php
@@ -11,6 +11,7 @@ class UserRole extends Model
     public $incrementing = false;
     public $timestamps = false;
 
+    protected $fillable = ['id', 'user_id', 'role_id'];
     protected $hidden = ['id', 'user_id', 'role_id'];
 
     public function role()

--- a/app/Services/RegisterAdminService.php
+++ b/app/Services/RegisterAdminService.php
@@ -7,6 +7,8 @@ use App\DomainValueObjects\UUIDGenerator\UUID;
 
 //Models
 use App\User;
+use App\Models\UserRole;
+use App\Models\Role;
 use App\Models\Organization;
 use App\DomainValueObjects\Location\Address;
 
@@ -25,7 +27,7 @@ class RegisterAdminService implements RegisterAdminContract
     $email,
     $password,
     $organization_id
-  ): User
+  )
   {
     try {
       $user = User::create([
@@ -34,11 +36,20 @@ class RegisterAdminService implements RegisterAdminContract
         'email' => $email,
         'password' => Hash::make($password)
       ]);
+
+      $role = UserRole::create([
+        'id' => UUID::generate(),
+        'user_id' => $user->id,
+        'role_id' => 1
+      ]);
+
+      $role_name = $user->role()->first();
+
     } catch (\Exception $e) {
       throw new UserCreatedFailed();
     }
 
-    return $user;
+    return [$user, $role, $role_name];
   }
 
   public function registerOrganization(

--- a/tests/Unit/AuthTests/RegisterTests/RegisterAdminControllerTest.php
+++ b/tests/Unit/AuthTests/RegisterTests/RegisterAdminControllerTest.php
@@ -90,7 +90,8 @@ class RegisterAdminControllerTest extends TestCase
       'user' => [
         'name' => "John Doe",
         'email' => "JohnDoe@email.com",
-      ]
+      ],
+      'role' => "Admin"
     ];
     $expectedResponse = json_encode($expectedResponse);
     $this->assertEquals($response, $expectedResponse);


### PR DESCRIPTION
# Description

When a user registers as admin, he now is an admin in our DB

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

phpunit, and register_admin route

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
